### PR TITLE
Fix unused type parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "1.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,16 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8"
+Dates = "<0.0.1, 1"
 GLM = "^1"
+LinearAlgebra = "<0.0.1, 1"
+Test = "<0.0.1, 1"
 julia = "^1.4"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Aqua", "Test"]

--- a/src/0_Structs_And_Enums.jl
+++ b/src/0_Structs_And_Enums.jl
@@ -13,14 +13,14 @@ struct FunctionEvaluationResult{T<:Real,R}
     function FunctionEvaluationResult(Input::Vector{T}, Output_::Missing, Error_::Symbol, Other_Output_::Union{Missing,NamedTuple} = missing) where T<:Real
         return new{T,T}(Input, Output_, Other_Output_, Error_)
     end
-    function FunctionEvaluationResult(Input::Vector{T}, Output::Vector{R}, Error_::Symbol, Other_Output_::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Real
-        return new{T,R}(Input, convert(Array{Union{Missing,R},1}, Output), Other_Output_, Error_)
-    end
-    function FunctionEvaluationResult(Input::Vector{T}, Output::Vector{Union{Missing,R}}, Error_::Symbol, Other_Output_::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Real
-        return new{T,R}(Input, Output, Other_Output_, Error_)
-    end
-    function FunctionEvaluationResult(Input::Vector{T}, Output::Vector{Missing}, Error_::Symbol, Other_Output_::Union{Missing,NamedTuple} = missing) where T<:Real
-        return new{T,T}(Input, Output, Other_Output_, Error_)
+    function FunctionEvaluationResult(Input::Vector{T}, Output::Vector{R}, Error_::Symbol, Other_Output_::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Union{Missing,<:Real}
+        if R === Missing
+            return new{T,T}(Input, Output, Other_Output_, Error_)
+        elseif R <: Real
+            return new{T,R}(Input, convert(Array{Union{Missing,R},1}, Output), Other_Output_, Error_)
+        else
+            return new{T,nonmissingtype(R)}(Input, Output, Other_Output_, Error_)
+        end
     end
 end
 

--- a/src/1_MainFunctions.jl
+++ b/src/1_MainFunctions.jl
@@ -158,10 +158,10 @@ function fixed_point(func::Function, Inputs::Real;
                        MaxIter = MaxIter, MaxM = MaxM, ExtrapolationPeriod = ExtrapolationPeriod, Dampening = Dampening, PrintReports = PrintReports, ReportingSigFig = ReportingSigFig,
                        ReplaceInvalids = ReplaceInvalids, ConditionNumberThreshold = ConditionNumberThreshold, quiet_errors = quiet_errors)
 end
-function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{R,2} = Array{T,2}(undef,size(Inputs)[1],0),
+function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{<:Real,2} = Array{T,2}(undef,size(Inputs)[1],0),
                     Algorithm::Symbol = :Anderson,  ConvergenceMetric::Function  = supnorm(input, output) = maximum(abs.(output .- input)),
                     ConvergenceMetricThreshold::Real = 1e-10, MaxIter::Integer = Integer(1000), MaxM::Integer = Integer(10), ExtrapolationPeriod::Integer = Integer(7), Dampening::Real = AbstractFloat(1.0),
-                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Real
+                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real
     # This code first tests if the input point is a fixed point. Then if it is not a while loop runs to try to find a fixed point.
     if (ConditionNumberThreshold < 1) error("ConditionNumberThreshold must be at least 1.")  end
     SimpleStartIndex = Integer(size(Outputs)[2])
@@ -181,7 +181,7 @@ function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{R,2} = 
         end
     end
     LengthOfArray = size(Inputs)[1]
-    output_type = promote_type(T,R)
+    output_type = promote_type(T,eltype(Outputs))
     final_other_output = other_outputs
     # Do an initial run if no runs have been done:
     if isempty(Outputs)

--- a/src/1_MainFunctions.jl
+++ b/src/1_MainFunctions.jl
@@ -161,7 +161,7 @@ end
 function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{R,2} = Array{T,2}(undef,size(Inputs)[1],0),
                     Algorithm::Symbol = :Anderson,  ConvergenceMetric::Function  = supnorm(input, output) = maximum(abs.(output .- input)),
                     ConvergenceMetricThreshold::Real = 1e-10, MaxIter::Integer = Integer(1000), MaxM::Integer = Integer(10), ExtrapolationPeriod::Integer = Integer(7), Dampening::Real = AbstractFloat(1.0),
-                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Real
+                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real
     # This code first tests if the input point is a fixed point. Then if it is not a while loop runs to try to find a fixed point.
     if (ConditionNumberThreshold < 1) error("ConditionNumberThreshold must be at least 1.")  end
     SimpleStartIndex = Integer(size(Outputs)[2])

--- a/src/1_MainFunctions.jl
+++ b/src/1_MainFunctions.jl
@@ -158,10 +158,10 @@ function fixed_point(func::Function, Inputs::Real;
                        MaxIter = MaxIter, MaxM = MaxM, ExtrapolationPeriod = ExtrapolationPeriod, Dampening = Dampening, PrintReports = PrintReports, ReportingSigFig = ReportingSigFig,
                        ReplaceInvalids = ReplaceInvalids, ConditionNumberThreshold = ConditionNumberThreshold, quiet_errors = quiet_errors)
 end
-function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{<:Real,2} = Array{T,2}(undef,size(Inputs)[1],0),
+function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{R,2} = Array{T,2}(undef,size(Inputs)[1],0),
                     Algorithm::Symbol = :Anderson,  ConvergenceMetric::Function  = supnorm(input, output) = maximum(abs.(output .- input)),
                     ConvergenceMetricThreshold::Real = 1e-10, MaxIter::Integer = Integer(1000), MaxM::Integer = Integer(10), ExtrapolationPeriod::Integer = Integer(7), Dampening::Real = AbstractFloat(1.0),
-                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real
+                    PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real where R<:Real
     # This code first tests if the input point is a fixed point. Then if it is not a while loop runs to try to find a fixed point.
     if (ConditionNumberThreshold < 1) error("ConditionNumberThreshold must be at least 1.")  end
     SimpleStartIndex = Integer(size(Outputs)[2])

--- a/src/1_MainFunctions.jl
+++ b/src/1_MainFunctions.jl
@@ -158,7 +158,7 @@ function fixed_point(func::Function, Inputs::Real;
                        MaxIter = MaxIter, MaxM = MaxM, ExtrapolationPeriod = ExtrapolationPeriod, Dampening = Dampening, PrintReports = PrintReports, ReportingSigFig = ReportingSigFig,
                        ReplaceInvalids = ReplaceInvalids, ConditionNumberThreshold = ConditionNumberThreshold, quiet_errors = quiet_errors)
 end
-function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{R,2} = Array{T,2}(undef,size(Inputs)[1],0),
+function fixed_point(func::Function, Inputs::Array{T, 2}; Outputs::Array{<:Real,2} = Array{T,2}(undef,size(Inputs)[1],0),
                     Algorithm::Symbol = :Anderson,  ConvergenceMetric::Function  = supnorm(input, output) = maximum(abs.(output .- input)),
                     ConvergenceMetricThreshold::Real = 1e-10, MaxIter::Integer = Integer(1000), MaxM::Integer = Integer(10), ExtrapolationPeriod::Integer = Integer(7), Dampening::Real = AbstractFloat(1.0),
                     PrintReports::Bool = false, ReportingSigFig::Integer = Integer(10), ReplaceInvalids::Symbol = :NoAction, ConditionNumberThreshold::Real = 1e3, quiet_errors::Bool = false, other_outputs::Union{Missing,NamedTuple} = missing) where T<:Real

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,0 +1,6 @@
+using Test
+@testset "Aqua" begin
+    using FixedPointAcceleration
+    import Aqua
+    Aqua.test_all(FixedPointAcceleration)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using FixedPointAcceleration
 using Test
 
 # Run tests
+println("Auto QUality Assurance")
+include("Aqua.jl")
 println("Test putting together iterates with jumps")
 include("TestPuttingInputsAndOutputsTogether.jl")
 println("Test simple Scalar function")


### PR DESCRIPTION
The PR fixes an ~~unbound~~ unused type parameter (a warning showed up in a downstream CI run). 

Additionally, I added tests with [Aqua](https://github.com/JuliaTesting/Aqua.jl) which checks for unbound type parameters and a few other things such as undefined exports.

---

Edit: Aqua detected a few more problems, I'll push a few more commits to address them.